### PR TITLE
Handle null user in Gate before callback

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,7 +36,7 @@ final class AppServiceProvider extends ServiceProvider
     public function bootGate(): void
     {
         Gate::before(function (mixed $user, string $ability): ?bool {
-            return $user->hasRole(DefaultRole::SUPER_ADMIN) ? true : null;
+            return $user?->hasRole(DefaultRole::SUPER_ADMIN) ? true : null;
         });
     }
 


### PR DESCRIPTION
Use the PHP null-safe operator so the Gate::before callback won't call hasRole on a null $user and won't error for guests