### PR TITLE
Add document pages endpoints and update locale

### DIFF
--- a/app/Http/Controllers/Customer/DocumentController.php
+++ b/app/Http/Controllers/Customer/DocumentController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Customer;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\DocumentPageResource;
 use App\Http\Resources\DocumentResource;
 use App\Repositories\Contracts\DocumentRepository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Class DocumentController
@@ -37,5 +39,46 @@ final class DocumentController extends Controller
         $documents = $this->repository->getPublished($queries);
 
         return DocumentResource::collection($documents);
+    }
+
+    /**
+     * Display the specified published document with lazy-loaded paginated pages.
+     *
+     * @param  Request  $request  The incoming HTTP request.
+     * @param  string  $id  The ID of the document.
+     * @return DocumentResource The formatted document resource.
+     */
+    public function show(string $id): DocumentResource
+    {
+        $document = $this->repository->retrieve($id);
+
+        return DocumentResource::make($document);
+    }
+
+    /**
+     * Display the paginated pages of a specified published document.
+     *
+     * @param  Request  $request  The incoming HTTP request containing optional filters.
+     * @param  string  $id  The ID of the document.
+     * @return JsonResponse The paginated collection of document pages.
+     */
+    public function getPages(Request $request, string $id): JsonResponse
+    {
+        $document = $this->repository->retrieve($id);
+
+        if (! $document) {
+            return response()->json([
+                'message' => 'Document not found',
+            ], 404);
+        }
+
+        $pages = $document
+            ->pages()
+            ->where('locale', app()->getLocale())
+            ->orderBy('page_number')
+            ->paginate((int) $request->query('per_page', 10));
+
+        return DocumentPageResource::collection($pages)
+            ->response();
     }
 }

--- a/app/Http/Controllers/Rest/DocumentRestController.php
+++ b/app/Http/Controllers/Rest/DocumentRestController.php
@@ -45,7 +45,7 @@ final class DocumentRestController extends Controller
             'paginate' => $request->query('per_page', 20),
         ]);
 
-        return DocumentResource::collection($this->repository->all($queries));
+        return DocumentResource::collection($this->repository->getNonArchived($queries));
     }
 
     /**

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -24,15 +24,22 @@ final class SetLocale
 
         $lang = config('app.locale');
 
-        if ($user && $user->preferred_language) {
-            $lang = ($user->preferred_language);
-        } elseif ($request->hasHeader('Accept-Language')) {
+        if ($request->hasHeader('Accept-Language')) {
             $lang = $request->header('Accept-Language');
-            if ($lang) {
-                $lang = substr($lang, 0, 2);
-                if (! \in_array($lang, ['en', 'fr'], true)) {
-                    $lang = 'en';
-                }
+            $lang = substr($lang, 0, 2);
+
+            if (! \in_array($lang, ['en', 'fr'], true)) {
+                $lang = 'en';
+            }
+
+            if ($user && $user->preferred_language !== $lang) {
+                $user->update(['preferred_language' => $lang]);
+            }
+        } else {
+            if ($user) {
+                $lang = $user->preferred_language;
+            } else {
+                $lang = 'fr';
             }
         }
 

--- a/app/Http/Resources/AdminResource.php
+++ b/app/Http/Resources/AdminResource.php
@@ -30,6 +30,7 @@ final class AdminResource extends JsonResource
             'email' => $this->resource->email,
             'avatar' => $this->resource->avatar,
             'roles' => $this->whenLoaded('roles'),
+            'preferred_language' => $this->resource->preferred_language,
             'permissions' => $this->whenLoaded('permissions'),
             'created_at' => $this->created_at,
         ];

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace App\Http\Resources;
 
+use App\Models\Category;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * Category Resource
+ *
+ * @property Category $resource
+ */
 final class CategoryResource extends JsonResource
 {
     /**
@@ -17,9 +23,9 @@ final class CategoryResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'id' => $this->id,
-            'name' => $this->name,
-            'slug' => $this->slug,
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+            'slug' => $this->resource->slug,
             'childrens' => CategoryResource::collection($this->whenLoaded('childrens')),
         ];
     }

--- a/app/Http/Resources/DocumentPageResource.php
+++ b/app/Http/Resources/DocumentPageResource.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace App\Http\Resources;
 
-use App\Models\Category;
+use App\Models\DocumentPage;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
- * @property Category $resource
+ * Resource for a document page.
+ *
+ * @property-read DocumentPage $resource
  */
-final class AdminCategoryResource extends JsonResource
+final class DocumentPageResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
@@ -22,9 +24,8 @@ final class AdminCategoryResource extends JsonResource
     {
         return [
             'id' => $this->resource->id,
-            'name' => $this->resource->getTranslations('name'),
-            'slug' => $this->resource->slug,
-            'childrens' => AdminCategoryResource::collection($this->whenLoaded('childrens')),
+            'page_number' => $this->resource->page_number,
+            'content' => $this->resource->content,
         ];
     }
 }

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -7,6 +7,8 @@ namespace App\Models;
 use App\Enums\DocumentStatus;
 use App\Enums\OcrStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -104,6 +106,18 @@ final class Document extends Model implements HasMedia
                 )?->getTemporaryUrl(now()->addHour()),
             ),
         );
+    }
+
+    #[Scope]
+    public function published(Builder $query): Builder
+    {
+        return $query->where('status', DocumentStatus::PUBLISHED);
+    }
+
+    #[Scope]
+    public function notDeleted(Builder $query): Builder
+    {
+        return $query->whereNot('status', DocumentStatus::ARCHIVED);
     }
 
     /**

--- a/app/Repositories/Contracts/DocumentRepository.php
+++ b/app/Repositories/Contracts/DocumentRepository.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Collection;
  * Defines the specific contract for Document data access operations, extending
  * the base repository contract for common CRUD operations.
  *
+ * @method Collection<int, Document> notDeleted()
+ *
  * @extends Repository<Document>
  */
 interface DocumentRepository extends Repository
@@ -35,4 +37,13 @@ interface DocumentRepository extends Repository
      * @return Document The updated document model.
      */
     public function togglePublish(Document|string $document): Document;
+
+    /**
+     * Retrieve a paginated or unpaginated list of non archived documents for all access,
+     * applying optional HTTP queries (filters, sorts, pagination).
+     *
+     * @param  array<string, mixed>  $queries  The associative array of query parameters.
+     * @return Collection<int, Document>|Paginator The collection of non archived documents.
+     */
+    public function getNonArchived(array $queries = []): Collection|Paginator;
 }

--- a/app/Repositories/Eloquent/DocumentRepositoryEloquent.php
+++ b/app/Repositories/Eloquent/DocumentRepositoryEloquent.php
@@ -71,4 +71,12 @@ final class DocumentRepositoryEloquent extends CommonRepository implements Docum
 
         return $updatedDoc;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNonArchived(array $queries = []): Collection|Paginator
+    {
+        return $this->handleMaybePaginatedQuery(fn () => $this->buildQuery()->notDeleted(), $queries);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -88,6 +88,12 @@ Route::middleware(['auth:sanctum', SetLocale::class])->group(function () {
 
     // Documents
     Route::get('/documents', [DocumentController::class, 'index'])->name(
-        'customer.documents',
+        'customer.documents.index',
     );
+    Route::get('/documents/{document}/pages', [DocumentController::class, 'getPages'])
+        ->name('customer.documents.pages')
+        ->whereUuid('document');
+    Route::get('/documents/{document}', [DocumentController::class, 'show'])
+        ->name('customer.documents.show')
+        ->whereUuid('document');
 });

--- a/tests/Feature/CategoryTest.php
+++ b/tests/Feature/CategoryTest.php
@@ -41,9 +41,10 @@ final class CategoryTest extends TestCase
         $response = $this->actingAs($admin, 'sanctum')->postJson(
             '/api/admin/categories',
             $payload,
+            ['Accept-Language' => 'fr'],
         );
 
-        $response->assertCreated()->assertJsonPath('data.name', 'Justice');
+        $response->assertCreated()->assertJsonPath('data.name', ['fr' => 'Justice', 'en' => 'Justice']);
 
         $this->assertDatabaseHas('categories', [
             'slug' => 'justice',

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -62,6 +62,7 @@ final class UserTest extends TestCase
                 'password' => 'new_password',
                 'password_confirmation' => 'new_password',
             ],
+            ['Accept-Language' => 'fr']
         );
 
         $response->assertStatus(422);


### PR DESCRIPTION
Add DocumentController::show and ::getPages; paginate pages by locale and return DocumentPageResource collections
Add DocumentPageResource and include pages in DocumentResource Add Document::published scope and add routes for documents.pages and documents.show with UUID constraints; rename documents index route Update SetLocale to prefer Accept-Language and persist user's preferred_language when it changes
Expose preferred_language in AdminResource and return translated names in AdminCategoryResource