### PR TITLE
Add localized title attributes and category filter

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -43,6 +44,20 @@ final class Category extends Model
     public function getRouteKeyName()
     {
         return 'slug';
+    }
+
+    public function titleFr(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->getTranslations('name', ['fr']),
+        );
+    }
+
+    public function titleEn(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->getTranslations('name', ['en']),
+        );
     }
 
     /**

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -42,6 +42,8 @@ use function Illuminate\Support\now;
  * @property Carbon|null $updated_at The date and time the document was last updated.
  * @property-read ?string $fr_document The link of the file in french.
  * @property-read ?string $en_document The link of the file in english.
+ * @property-read string $title_fr The title of the document in french.
+ * @property-read string $title_en The title of the document in english.
  */
 #[
     Fillable([
@@ -105,6 +107,20 @@ final class Document extends Model implements HasMedia
                     'document_en',
                 )?->getTemporaryUrl(now()->addHour()),
             ),
+        );
+    }
+
+    public function titleFr(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->getTranslations('title', ['fr']),
+        );
+    }
+
+    public function titleEn(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->getTranslations('title', ['en']),
         );
     }
 

--- a/app/Repositories/Eloquent/DocumentRepositoryEloquent.php
+++ b/app/Repositories/Eloquent/DocumentRepositoryEloquent.php
@@ -10,6 +10,7 @@ use App\Repositories\CommonRepository;
 use App\Repositories\Contracts\DocumentRepository;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Collection;
+use Spatie\QueryBuilder\AllowedFilter;
 
 /**
  * Class DocumentRepositoryEloquent
@@ -23,6 +24,7 @@ final class DocumentRepositoryEloquent extends CommonRepository implements Docum
 {
     /**
      * The Eloquent model representing the Document.
+     *ors
      *
      * @var class-string<Document>
      */
@@ -34,7 +36,14 @@ final class DocumentRepositoryEloquent extends CommonRepository implements Docum
             'includes' => ['category', 'uploadedBy'],
             'relations' => ['category', 'uploadedBy'],
             'sorts' => ['created_at', 'published_at'],
-            'filters' => ['status', 'category_id'],
+            'filters' => [
+                'status',
+                'category_id',
+                AllowedFilter::callback('category', fn ($query, $value) => $query->whereRelation('category', function ($query) use ($value) {
+                    $query->where('slug', $value)
+                        ->orWhere('id', $value);
+                })),
+            ],
         ]);
     }
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -18,7 +18,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => [env('FRONTEND_URL'), env('ADMIN_URL'), 'http://localhost'],
+    'allowed_origins' => [env('FRONTEND_URL'), env('ADMIN_URL'), 'http://localhost:300/', 'http://localhost/'],
 
     'allowed_origins_patterns' => [],
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,5 +9,8 @@ php artisan view:cache
 echo "Running migrations..."
 php artisan migrate --force
 
+echo "Seeding database..."
+php artisan db:seed --force
+
 echo "Starting Supervisor..."
 exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
Add titleFr/titleEn Attribute accessors to Category and Document models and add docblock property annotations.

Use Spatie AllowedFilter callback in DocumentRepository to allow filtering by category slug or id.

Run database seeder from docker entrypoint and add localhost variants to CORS allowed_origins.