### PR TITLE
Return uploaded document resource

### DIFF
--- a/app/Http/Controllers/Rest/DocumentRestController.php
+++ b/app/Http/Controllers/Rest/DocumentRestController.php
@@ -77,7 +77,7 @@ final class DocumentRestController extends Controller
      */
     public function upload(UploadDocumentRequest $request, Document $document): JsonResponse
     {
-        $this->authorize('create', $document);
+        $this->authorize('update', $document);
 
         if ($request->hasFile('file_fr')) {
             $document->addMediaFromRequest('file_fr')->toMediaCollection(
@@ -93,7 +93,9 @@ final class DocumentRestController extends Controller
             ProcessDocumentOcr::dispatch($document->id, 'en');
         }
 
-        return $this->successResponse();
+        $document->refresh();
+
+        return DocumentResource::make($document)->response();
     }
 
     /**

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -30,9 +30,11 @@ final class HorizonServiceProvider extends HorizonApplicationServiceProvider
     protected function gate(): void
     {
         Gate::define('viewHorizon', function ($user = null) {
-            return in_array(optional($user)->email, [
-                //
-            ]);
+
+            $isLocal = $this->app->environment('local');
+            $isStaging = $this->app->environment('staging');
+
+            return $isLocal || $isStaging;
         });
     }
 }

--- a/config/cors.php
+++ b/config/cors.php
@@ -18,7 +18,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => [env('FRONTEND_URL'), env('ADMIN_URL'), 'http://localhost:300/', 'http://localhost/'],
+    'allowed_origins' => [env('FRONTEND_URL'), env('ADMIN_URL'), 'http://localhost:3000/', 'http://localhost/'],
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
Allow Horizon UI in local and staging environments by adjusting the viewHorizon gate to check app environment instead of whitelisting emails.

Fix CORS allowed_origins to use http://localhost:3000/ instead of http://localhost:300/.